### PR TITLE
Let readers detect RSS and other output formats

### DIFF
--- a/themes/lilac-revenge/layouts/partials/head.html
+++ b/themes/lilac-revenge/layouts/partials/head.html
@@ -6,6 +6,20 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="manifest" href="site.webmanifest">
 <link rel="apple-touch-icon" href="icon.png">
+{{ range .AlternativeOutputFormats -}}
+  {{ printf `<link rel="%s" type="%s" href="%s" title="%s — %s" />` .Rel .MediaType.Type .Permalink $.Title $.Site.Title | safeHTML }}
+{{ end -}}
+
+{{- /*
+  Always point to the news feed regardless of what page we're on since it's
+  probably the only one most readers will want to subscribe to anyways.
+*/ -}}
+{{- with .GetPage "/news" }}
+  {{- $newsPage := . }}
+  {{- with .OutputFormats.Get "rss" -}}
+    {{ printf `<link rel="feed" type="%s" href="%s" title="%s — %s" />`  .MediaType.Type .Permalink $newsPage.Title $.Site.Title | safeHTML }}
+  {{- end }}
+{{- end }}
 <meta name="theme-color" content="#fafafa">
 
 {{ hugo.Generator }}


### PR DESCRIPTION
Adds a link to any alternate output formats generated for the particular page (eg. the RSS feed for all updates on the home page, or the RSS feed on the news page) and adds a link with rel="feed" to every page so that the news feed RSS is detected by feed readers even if we've pasted an individual news article or the home page in to their subscription field.