### PR TITLE
use logLevel info instead of verbose in hugo build

### DIFF
--- a/.github/workflows/publish-mainline.yaml
+++ b/.github/workflows/publish-mainline.yaml
@@ -30,7 +30,7 @@ jobs:
             NEXT_PUBLIC_TINA_CLIENT_ID: ${{ secrets.TINA_CMS_CLIENT_ID }}
             TINA_TOKEN: ${{ secrets.TINA_CMS_RO_TOKEN }}
         - name: Build Hugo
-          run:  hugo --environment production --verbose
+          run:  hugo --environment production --logLevel info
         - name: Configure AWS Credentials
           uses: aws-actions/configure-aws-credentials@v4
           with:
@@ -41,4 +41,4 @@ jobs:
             role-duration-seconds: 1200
             role-session-name: ProdHugoPublisherWorkflow
         - name: Deploy
-          run: hugo deploy --environment production --verbose
+          run: hugo deploy --environment production --logLevel info

--- a/.github/workflows/publish-staging.yaml
+++ b/.github/workflows/publish-staging.yaml
@@ -30,7 +30,7 @@ jobs:
             NEXT_PUBLIC_TINA_CLIENT_ID: ${{ secrets.TINA_CMS_CLIENT_ID }}
             TINA_TOKEN: ${{ secrets.TINA_CMS_RO_TOKEN }}
         - name: Build Hugo
-          run:  hugo --environment staging --verbose
+          run:  hugo --environment staging --logLevel info
         - name: Configure AWS Credentials
           uses: aws-actions/configure-aws-credentials@v4
           with:
@@ -41,4 +41,4 @@ jobs:
             role-duration-seconds: 1200
             role-session-name: StagingHugoPublisherWorkflow
         - name: Deploy
-          run: hugo deploy --environment staging --verbose
+          run: hugo deploy --environment staging --logLevel info


### PR DESCRIPTION
Hugo doesn't have a verbose option anymore because all the logging options got rolled into `logLevel`. `info` does what `verbose` used to.